### PR TITLE
Update HTTP Client to take headers to prevent 403 errors

### DIFF
--- a/elections.cabal
+++ b/elections.cabal
@@ -12,9 +12,11 @@ library
   hs-source-dirs:      src
   build-depends:       base >=4.7 && <5
                      , bytestring
+                     , case-insensitive
                      , cassava
                      , directory
                      , http-conduit
+                     , http-types
                      , scalpel
                      , split
                      , text

--- a/src/Network/HTTPClient.hs
+++ b/src/Network/HTTPClient.hs
@@ -1,19 +1,29 @@
 module Network.HTTPClient (fetchWebPage, FetchException(..)) where
 
+import Network.HTTP.Types.Header (hUserAgent, hAccept, hAcceptLanguage, hCookie, hReferer, hCacheControl)
 import Control.Exception (Exception, SomeException, throwIO, toException)
+import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
+import Data.CaseInsensitive (mk)
 import Network.HTTP.Simple
+    ( parseRequest_,
+      getResponseBody,
+      getResponseStatusCode,
+      httpLBS,
+      setRequestHeader )
 
 -- Define a custom exception type
 data FetchException = FetchException Int String deriving (Show)
 
 instance Exception FetchException
 
-fetchWebPage :: String -> IO String
-fetchWebPage url = do
-  response <- httpLBS (parseRequest_ url)
+fetchWebPage :: String -> [(String, String)] -> IO String
+fetchWebPage url headers = do
+  -- Create a request with headers passed as an argument
+  let request = foldr (\(name, value) req -> setRequestHeader (mk $ BS.pack name) [BS.pack value] req) (parseRequest_ url) headers
+  response <- httpLBS request
   let statusCode = getResponseStatusCode response
   if statusCode /= 200
     then throwIO (FetchException statusCode ("Failed to fetch URL: " ++ url ++ " with status code: " ++ show statusCode))

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -9,7 +9,7 @@ import qualified Data.Text.Encoding as TE
 import qualified Data.Vector as V
 import Elections (Constituency (..), generateURLs)
 import Network.HTTPClient (fetchWebPage)
-import Parser.HTMLParser (extractTableRows, constituencyNameFetcher)
+import Parser.HTMLParser (constituencyNameFetcher, extractTableRows)
 import System.Directory (doesFileExist, removeFile)
 import Test.Hspec
 
@@ -17,8 +17,35 @@ main :: IO ()
 main = hspec $ do
   describe "fetchWebPage" $ do
     it "fetches the webpage content" $ do
-      content <- fetchWebPage "http://example.com"
+      content <- fetchWebPage "http://example.com" []
       content `shouldContain` "<html>"
+
+  describe "fetchElectionWebPage" $ do
+    it "fetches the election webpage content" $ do
+      let headers =
+            [ (":authority", "results.eci.gov.in"),
+              (":method", "GET"),
+              (":path", "/AcResultGenOct2024/ConstituencywiseU0867.htm"),
+              (":scheme", "https"),
+              ("accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"),
+              ("accept-encoding", "gzip, deflate, br, zstd"),
+              ("accept-language", "en-IN,en;q=0.9,hi-IN;q=0.8,hi;q=0.7,en-GB;q=0.6,en-US;q=0.5"),
+              ("cache-control", "max-age=0"),
+              ("cookie", "RT=\"z=1&dm=results.eci.gov.in&si=b16b28a4-e8cf-4f1e-ba3c-fd48c9cbcb95&ss=m2873m95&sl=e&tt=k3p&bcn=%2F%2F17de4c19.akstat.io%2F&ld=2kfyb&ul=2qql0\""),
+              ("dnt", "1"),
+              ("priority", "u=0, i"),
+              ("referer", "https://results.eci.gov.in/AcResultGenOct2024/ConstituencywiseU0867.htm"),
+              ("sec-ch-ua", "\"Google Chrome\";v=\"129\", \"Not=A?Brand\";v=\"8\", \"Chromium\";v=\"129\""),
+              ("sec-ch-ua-mobile", "?0"),
+              ("sec-ch-ua-platform", "\"macOS\""),
+              ("sec-fetch-dest", "document"),
+              ("sec-fetch-mode", "navigate"),
+              ("sec-fetch-site", "same-origin"),
+              ("upgrade-insecure-requests", "1"),
+              ("user-agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36")
+            ]
+      content <- fetchWebPage "https://results.eci.gov.in/AcResultGenOct2024/ConstituencywiseU0867.htm" headers
+      content `shouldContain` "html"
 
   describe "extractTableRows" $ do
     it "extracts rows from HTML table" $ do
@@ -55,6 +82,5 @@ main = hspec $ do
     it "generates the correct number of constituencies" $ do
       let actualConstituencies = generateURLs
       length actualConstituencies `shouldBe` 543
-
 
 expectedRows = [["1", "AMAR SHARADRAO KALE", "Nationalist Congress Party – Sharadchandra Pawar", "530761", "2345", "533106", "48.68"], ["2", "RAMDAS CHANDRABHAN TADAS", "Bharatiya Janata Party", "449599", "1859", "451458", "41.23"]]


### PR DESCRIPTION
Take Request headers in the HTTP requests to prevent 403 errors.